### PR TITLE
Handle associations in rails 5

### DIFF
--- a/lib/secretary/dirty_associations.rb
+++ b/lib/secretary/dirty_associations.rb
@@ -133,7 +133,11 @@ module Secretary
     end
 
     def __compat_clear_attribute_changes(name)
-      if respond_to?(:clear_attribute_changes, true)
+      if respond_to?(:clear_attribute_change, true)
+        # Rails 5.0+
+        # call directly
+        attributes_changed_by_setter.except!(name)
+      elsif respond_to?(:clear_attribute_changes, true)
         # Rails 4.2+
         clear_attribute_changes([name])
       else


### PR DESCRIPTION
Not sure of this gem is still supported, but this is a workaround to get association tracking working in rails 5. The behavior of clear_attribute_changes changed where it looks for the attribute in the DB and raises an error that the association doesn't exist in the model's table. This fix calls directly the old clear_attribute_changes functionality from rails 4.